### PR TITLE
Release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.5
+* Bump up plugin version.
+* Tested up to WP 6.8
+* Update README docs.
+
 ## 1.0.4
 * Update README description.
 * Tested up to WP 6.7.2.

--- a/censor-order-details.php
+++ b/censor-order-details.php
@@ -3,7 +3,7 @@
  * Plugin Name: Censor Order Details
  * Plugin URI:  https://github.com/badasswp/censor-order-details
  * Description: Hide sensitive customer order details in WooCommerce.
- * Version:     1.0.4
+ * Version:     1.0.5
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,11 @@ Sometimes, customer data can contain sensitive information which you do not want
 
 == Changelog ==
 
+= 1.0.5 =
+* Bump up plugin version.
+* Tested up to WP 6.8
+* Update README docs.
+
 = 1.0.4 =
 * Update README description.
 * Tested up to WP 6.7.2.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: badasswp
 Tags: censor, customer, order, details, woocommerce.
 Requires at least: 4.0
-Tested up to: 6.7.2
-Stable tag: 1.0.4
+Tested up to: 6.8
+Stable tag: 1.0.5
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This release does not contain any functional change:

* Bump up plugin version.
* Tested up to WP 6.8
* Update README docs.